### PR TITLE
Add alternate pen mode support and P8 Ulab example.

### DIFF
--- a/examples/ulab/the_matrix.py
+++ b/examples/ulab/the_matrix.py
@@ -1,0 +1,85 @@
+import gc
+import time
+import random
+from ulab import numpy
+from interstate75 import Interstate75, DISPLAY_INTERSTATE75_128X128
+from picographics import PEN_P8
+
+i75 = Interstate75(display=DISPLAY_INTERSTATE75_128X128, pen_type=PEN_P8)
+graphics = i75.display
+
+width = i75.width
+height = i75.height
+
+"""
+HELLO NEO.
+"""
+
+# MAXIMUM OVERKILL
+# machine.freq(250_000_000)
+
+# Fill half the palette with GREEEN
+for g in range(128):
+    _ = graphics.create_pen(0, g, 0)
+
+# And half with bright green for white sparkles
+for g in range(128):
+    _ = graphics.create_pen(128, 128 + g, 128)
+
+
+def update():
+
+    for _ in range(4):
+        x = random.randint(0, width - 1)
+        y = random.randint(0, height - 11)
+        m = random.randint(30, 127)
+        for oy in range(10):
+            matrix[y + oy][x] = random.randint(0, m) / 255.0
+        matrix[y + 10][x] = random.randint(128, 255) / 255.0
+
+    # Propagate downwards
+    old = numpy.ndarray(matrix)
+    matrix[:] = numpy.roll(matrix, 1, axis=0)
+    matrix[:] *= 0.59
+    matrix[:] += old * 0.39
+
+
+def draw():
+    # Copy the effect to the framebuffer
+    memoryview(graphics)[:] = numpy.ndarray(numpy.clip(matrix, 0, 1) * 254, dtype=numpy.uint8).tobytes()
+    i75.update()
+
+
+matrix = numpy.zeros((height, width))
+
+t_count = 0
+t_total = 0
+
+
+while True:
+    tstart = time.ticks_ms()
+    gc.collect()
+    update()
+    draw()
+    tfinish = time.ticks_ms()
+
+    total = tfinish - tstart
+    t_total += total
+    t_count += 1
+
+    if t_count == 60:
+        per_frame_avg = t_total / t_count
+        print(f"60 frames in {t_total}ms, avg {per_frame_avg:.02f}ms per frame, {1000/per_frame_avg:.02f} FPS")
+        t_count = 0
+        t_total = 0
+
+    # pause for a moment (important or the USB serial device will fail)
+    # try to pace at 60fps or 30fps
+    if total > 1000 / 30:
+        time.sleep(0.0001)
+    elif total > 1000 / 60:
+        t = 1000 / 30 - total
+        time.sleep(t / 1000)
+    else:
+        t = 1000 / 60 - total
+        time.sleep(t / 1000)

--- a/modules/rp2040/interstate75.py
+++ b/modules/rp2040/interstate75.py
@@ -1,5 +1,5 @@
 from pimoroni import RGBLED, Button
-from picographics import PicoGraphics, DISPLAY_INTERSTATE75_32X32, DISPLAY_INTERSTATE75_64X32, DISPLAY_INTERSTATE75_96X32, DISPLAY_INTERSTATE75_96X48, DISPLAY_INTERSTATE75_128X32, DISPLAY_INTERSTATE75_64X64, DISPLAY_INTERSTATE75_128X64, DISPLAY_INTERSTATE75_192X64, DISPLAY_INTERSTATE75_256X64, DISPLAY_INTERSTATE75_128X128
+from picographics import PicoGraphics, PEN_RGB888, DISPLAY_INTERSTATE75_32X32, DISPLAY_INTERSTATE75_64X32, DISPLAY_INTERSTATE75_96X32, DISPLAY_INTERSTATE75_96X48, DISPLAY_INTERSTATE75_128X32, DISPLAY_INTERSTATE75_64X64, DISPLAY_INTERSTATE75_128X64, DISPLAY_INTERSTATE75_192X64, DISPLAY_INTERSTATE75_256X64, DISPLAY_INTERSTATE75_128X128
 from pimoroni_i2c import PimoroniI2C
 import hub75
 import sys
@@ -43,9 +43,9 @@ class Interstate75:
     # Count Constants
     NUM_SWITCHES = 2
 
-    def __init__(self, display, panel_type=hub75.PANEL_GENERIC, stb_invert=False, color_order=hub75.COLOR_ORDER_RGB):
+    def __init__(self, display, panel_type=hub75.PANEL_GENERIC, stb_invert=False, color_order=hub75.COLOR_ORDER_RGB, pen_type=PEN_RGB888):
         self.interstate75w = "Pico W" in sys.implementation._machine
-        self.display = PicoGraphics(display=display)
+        self.display = PicoGraphics(display=display, pen_type=pen_type)
         self.width, self.height = self.display.get_bounds()
 
         out_width = self.width

--- a/modules/rp2350/interstate75.py
+++ b/modules/rp2350/interstate75.py
@@ -1,5 +1,5 @@
 from pimoroni import Button
-from picographics import PicoGraphics, DISPLAY_INTERSTATE75_32X32, DISPLAY_INTERSTATE75_64X32, DISPLAY_INTERSTATE75_96X32, DISPLAY_INTERSTATE75_96X48, DISPLAY_INTERSTATE75_128X32, DISPLAY_INTERSTATE75_64X64, DISPLAY_INTERSTATE75_128X64, DISPLAY_INTERSTATE75_192X64, DISPLAY_INTERSTATE75_256X64, DISPLAY_INTERSTATE75_128X128
+from picographics import PicoGraphics, PEN_RGB888, DISPLAY_INTERSTATE75_32X32, DISPLAY_INTERSTATE75_64X32, DISPLAY_INTERSTATE75_96X32, DISPLAY_INTERSTATE75_96X48, DISPLAY_INTERSTATE75_128X32, DISPLAY_INTERSTATE75_64X64, DISPLAY_INTERSTATE75_128X64, DISPLAY_INTERSTATE75_192X64, DISPLAY_INTERSTATE75_256X64, DISPLAY_INTERSTATE75_128X128
 from pimoroni_i2c import PimoroniI2C
 import hub75
 import plasma
@@ -40,8 +40,8 @@ class Interstate75:
     # Count Constants
     NUM_SWITCHES = 3
 
-    def __init__(self, display, panel_type=hub75.PANEL_GENERIC, stb_invert=False, color_order=hub75.COLOR_ORDER_RGB):
-        self.display = PicoGraphics(display=display)
+    def __init__(self, display, panel_type=hub75.PANEL_GENERIC, stb_invert=False, color_order=hub75.COLOR_ORDER_RGB, pen_type=PEN_RGB888):
+        self.display = PicoGraphics(display=display, pen_type=pen_type)
         self.width, self.height = self.display.get_bounds()
 
         out_width = self.width


### PR DESCRIPTION
This PR adds the missing support for alternate pen types back into Interstate 75.

We've always just supported RGB888 since Hub75 displays are usually small enough (even the 128x128 monster is only a 65k front + 65k back buffer) that the RAM isn't a constraint. However, modes like P8 (8-bit palette mode) have benefits other than reduced memory footprint (palette swaps, cycling and other tricks).

Note: I have benchmarked a roughly 6ms time to flip the 8-bit palette buffer to the display at 250MHz, this is a huge cost over the <1ms flip of RGB888. You still have ~10ms for user code to hit a respectable framerate, but definitely reserve 8-bit for when you *really* want the RAM, or you *really* want palette swaps/cycling or other palette mode tricks.

RGB565 is also supported, but will only save you ~32k (the back buffer is always fixed at 65k, 10 bits per channel) and will be similarly expensive to flip. Probably don't use it 😆 