### PR TITLE
Force FindPython to find Python3

### DIFF
--- a/boards/common.cmake
+++ b/boards/common.cmake
@@ -2,7 +2,7 @@
 set(Python_FIND_VIRTUALENV "FIRST")
 set(Python_FIND_UNVERSIONED_NAMES "FIRST")
 set(Python_FIND_STRATEGY "LOCATION")
-find_package (Python COMPONENTS Interpreter Development)
+find_package (Python3 COMPONENTS Interpreter Development)
 
 message("dir2uf2/py_decl: Using Python ${Python_EXECUTABLE}")
 


### PR DESCRIPTION
Though FindPython claims to prefer 3 over 2, it doesn't with the settings in this cmake file. I assume there's no reason to ever want 2 (py_decl uses 3 syntax), so forcing this to find Python3 works.